### PR TITLE
Clarify that the symbol table and string table offsets are relative to the mach-o header and not the start of the file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1244,7 +1244,7 @@ Common to all load command structures. For this structure, set to `sizeof(symta
 
 `symoff`
 
-An integer containing the byte offset from the start of the file to the location of the symbol table entries. The symbol table is an array of `nlist` data structures.
+An integer containing the byte offset relative to the start of the mach-o header to the location of the symbol table entries. The symbol table is an array of `nlist` data structures.
 
 `nsyms`
 
@@ -1252,7 +1252,7 @@ An integer indicating the number of entries in the symbol table.
 
 `stroff`
 
-An integer containing the byte offset from the start of the image to the location of the string table.
+An integer containing the byte offset relative to the start of the mach-o header to the location of the string table.
 
 `strsize`
 


### PR DESCRIPTION
The `symtab_command.symoff` and `symtab_command.stroff` values appear to be relative to the start of the mach-o header rather than absolute offsets within the file. This is mainly relevant for universal binaries.

Some evidence: MachOExplorer computes the symbol table offset as follows

https://github.com/everettjf/MachOExplorer/blob/173122e2a0dae9633f792bd4399a6ce832596458/src/libmoex/node/loadcmd/LoadCommand_SYMTAB.h#L77-L79